### PR TITLE
📚 Fix: Update broken ARCHITECTURE.md links

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -294,10 +294,3 @@ workspace-backup-*/
 # User identity configuration contains personal information and should not be committed
 .claudedirector/config/user_identity.yaml
 **/user_identity.yaml
-
-# ======================================
-# USER CONFIGURATION PROTECTION
-# ======================================
-# User identity configuration contains personal information and should not be committed
-.claudedirector/config/user_identity.yaml
-**/user_identity.yaml

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -11,7 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 - **🏗️ Complete Architecture Documentation**: Comprehensive system architecture with enhanced visual clarity
-  - **ARCHITECTURE.md**: Complete system diagrams with legends, color coding, and flow descriptions
+  - **architecture/**: Complete system diagrams with legends, color coding, and flow descriptions
   - **IMPLEMENTATION_GUIDE.md**: Developer implementation guide with code examples and best practices
   - **TECHNICAL_INDEX.md**: Consolidated technical documentation index for easy navigation
   - **Universal diagram reference**: Consistent visual conventions across all technical diagrams
@@ -49,7 +49,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - **📚 Comprehensive Root README**: Restored strategic value proposition with immediate business impact demonstration
   - **30-Second Demo**: Clear before/after transformation showing fragmented strategy → systematic strategic thinking
-  - **Quantified ROI Metrics**: $50K-100K cost avoidance with 40-60% strategic decision velocity improvement  
+  - **Quantified ROI Metrics**: $50K-100K cost avoidance with 40-60% strategic decision velocity improvement
   - **10-Second Quickstart**: Zero-configuration setup for both Cursor and Claude Chat users
   - **Progressive User Journey**: Value recognition → quick start → advanced capabilities → executive communication
   - **Real Strategic Scenarios**: Platform investment justification, crisis resolution, architecture decisions

--- a/docs/GETTING_STARTED.md
+++ b/docs/GETTING_STARTED.md
@@ -94,7 +94,7 @@ Once configured, ClaudeDirector automatically:
 - **[🤖 Meet Your AI Directors](CAPABILITIES.md)** - Complete persona and capability overview
 - **[🎯 Role-Specific Guide](ROLES_GUIDE.md)** - Deep dive into your specific leadership role
 - **[🧠 Strategic Frameworks](STRATEGIC_FRAMEWORKS_GUIDE.md)** - 25+ proven methodologies
-- **[🏗️ Architecture Guide](ARCHITECTURE.md)** - Technical implementation details
+- **[🏗️ Architecture Guide](architecture/OVERVIEW.md)** - Technical implementation details
 
 ---
 

--- a/docs/ROLES_GUIDE.md
+++ b/docs/ROLES_GUIDE.md
@@ -290,7 +290,7 @@ Let me help you design metrics that connect engineering work to user value...
 - **[🚀 Getting Started](GETTING_STARTED.md)** - Quick setup and first strategic question
 - **[🤖 Full Capabilities](CAPABILITIES.md)** - Complete persona and framework overview
 - **[🧠 Strategic Frameworks](STRATEGIC_FRAMEWORKS_GUIDE.md)** - 25+ proven methodologies
-- **[🏗️ Architecture Guide](ARCHITECTURE.md)** - Technical implementation details
+- **[🏗️ Architecture Guide](architecture/OVERVIEW.md)** - Technical implementation details
 
 ---
 

--- a/docs/TECHNICAL_INDEX.md
+++ b/docs/TECHNICAL_INDEX.md
@@ -7,10 +7,10 @@
 ## 🏗️ **Core Architecture**
 
 ### **System Design**
-- **[Architecture Overview](ARCHITECTURE.md)** - Complete system architecture with diagrams
-- **[Transparency System](ARCHITECTURE.md#transparency-system-architecture)** - Real-time AI capability disclosure
-- **[Multi-Persona Coordination](ARCHITECTURE.md#multi-persona-collaboration-system)** - Cross-functional collaboration patterns
-- **[Performance Architecture](ARCHITECTURE.md#performance-architecture)** - Optimization and scaling strategies
+- **[Architecture Overview](architecture/OVERVIEW.md)** - Complete system architecture with diagrams
+- **[Transparency System](architecture/COMPONENTS.md#transparency-system-architecture)** - Real-time AI capability disclosure
+- **[Multi-Persona Coordination](architecture/PATTERNS.md#multi-persona-collaboration-patterns)** - Cross-functional collaboration patterns
+- **[Performance Architecture](architecture/OVERVIEW.md#performance-requirements)** - Optimization and scaling strategies
 
 ### **Technical Implementation**
 - **[MCP Integration Assessment](technical/mcp-integration-technical-assessment.md)** - Detailed technical analysis and implementation plan
@@ -54,9 +54,9 @@
 ## 🔧 **MCP Integration**
 
 ### **Technical Implementation**
-- **[MCP Server Architecture](ARCHITECTURE.md#mcp-integration-architecture)** - Server ecosystem and capabilities
-- **[Enhancement Decision Flow](ARCHITECTURE.md#enhancement-decision-flow)** - Intelligent routing logic
-- **[Performance Optimization](ARCHITECTURE.md#performance-architecture)** - Caching and optimization strategies
+- **[MCP Server Architecture](architecture/COMPONENTS.md#mcp-integration-architecture)** - Server ecosystem and capabilities
+- **[Enhancement Decision Flow](architecture/COMPONENTS.md#enhancement-decision-flow)** - Intelligent routing logic
+- **[Performance Optimization](architecture/OVERVIEW.md#performance-requirements)** - Caching and optimization strategies
 
 ### **Development Resources**
 - **[Technical Assessment](technical/mcp-integration-technical-assessment.md)** - Complete implementation analysis
@@ -72,19 +72,19 @@
 | Component | Purpose | Documentation | Implementation |
 |-----------|---------|---------------|----------------|
 | **Persona Manager** | Strategic advisor selection | [Personas](../framework/PERSONAS.md) | [Core System](../lib/claudedirector/) |
-| **Transparency Engine** | Real-time capability disclosure | [Architecture](ARCHITECTURE.md#transparency-system-architecture) | [Implementation](../lib/claudedirector/transparency/) |
+| **Transparency Engine** | Real-time capability disclosure | [Architecture](architecture/COMPONENTS.md#transparency-system-architecture) | [Implementation](../lib/claudedirector/transparency/) |
 | **Framework Detection** | Strategic methodology attribution | [Frameworks](STRATEGIC_FRAMEWORKS_GUIDE.md) | [Detection Engine](../lib/claudedirector/transparency/) |
-| **MCP Client** | Server communication | [MCP Integration](ARCHITECTURE.md#mcp-integration-architecture) | [Technical Assessment](technical/mcp-integration-technical-assessment.md) |
-| **Multi-Persona Coordinator** | Cross-functional collaboration | [Multi-Persona Guide](ARCHITECTURE.md#multi-persona-collaboration-system) | [Transparency System](../lib/claudedirector/transparency/) |
+| **MCP Client** | Server communication | [MCP Integration](architecture/COMPONENTS.md#mcp-integration-architecture) | [Technical Assessment](technical/mcp-integration-technical-assessment.md) |
+| **Multi-Persona Coordinator** | Cross-functional collaboration | [Multi-Persona Guide](architecture/PATTERNS.md#multi-persona-collaboration-patterns) | [Transparency System](../lib/claudedirector/transparency/) |
 
 ### **Enhancement Components**
 
 | MCP Server | Capability | Personas | Documentation |
 |------------|------------|----------|---------------|
 | **Sequential** | Strategic analysis, business modeling | Diego, Camille, Alvaro | [Technical Assessment](technical/mcp-integration-technical-assessment.md) |
-| **Context7** | Framework patterns, architectural best practices | Martin, Rachel | [Architecture Overview](ARCHITECTURE.md#mcp-server-ecosystem) |
-| **Magic** | UI generation, visual design | Rachel, Alvaro | [MCP Integration](ARCHITECTURE.md#mcp-integration-architecture) |
-| **Playwright** | Testing automation, validation | All personas | [Enhancement Layer](ARCHITECTURE.md#enhancement-layer) |
+| **Context7** | Framework patterns, architectural best practices | Martin, Rachel | [Architecture Overview](architecture/COMPONENTS.md#mcp-server-ecosystem) |
+| **Magic** | UI generation, visual design | Rachel, Alvaro | [MCP Integration](architecture/COMPONENTS.md#mcp-integration-architecture) |
+| **Playwright** | Testing automation, validation | All personas | [Enhancement Layer](architecture/COMPONENTS.md#enhancement-layer) |
 
 ---
 
@@ -97,7 +97,7 @@
 
 ### **Testing Strategy**
 - **[Comprehensive Testing Plan](technical/mcp-integration-technical-assessment.md#testing-strategy)** - Unit, integration, and user acceptance testing
-- **[Performance Testing](ARCHITECTURE.md#performance-targets)** - Response time and scalability validation
+- **[Performance Testing](architecture/OVERVIEW.md#performance-requirements)** - Response time and scalability validation
 - **[Error Scenario Testing](technical/mcp-integration-technical-assessment.md#risk-assessment--mitigation)** - Graceful degradation validation
 
 ---
@@ -105,54 +105,54 @@
 ## 🚀 **Development & Deployment**
 
 ### **Development Environment**
-- **[Project Structure](ARCHITECTURE.md#implementation-architecture)** - Complete development environment setup
-- **[Module Architecture](ARCHITECTURE.md#module-architecture)** - Core module organization and responsibilities
+- **[Project Structure](architecture/OVERVIEW.md#implementation-architecture)** - Complete development environment setup
+- **[Module Architecture](architecture/COMPONENTS.md#module-architecture)** - Core module organization and responsibilities
 - **[Development Workflow](technical/mcp-integration-technical-assessment.md#development-workflow)** - Standards and review process
 
 ### **Deployment Models**
-- **[Cursor Integration](ARCHITECTURE.md#cursor-integration-primary)** - Primary deployment with persistent memory
-- **[Claude Chat Integration](ARCHITECTURE.md#claude-chat-integration)** - Secondary deployment model
-- **[Scalability Considerations](ARCHITECTURE.md#scalability-considerations)** - Horizontal and vertical scaling strategies
+- **[Cursor Integration](architecture/OVERVIEW.md#cursor-integration-primary)** - Primary deployment with persistent memory
+- **[Claude Chat Integration](architecture/OVERVIEW.md#claude-chat-integration)** - Secondary deployment model
+- **[Scalability Considerations](architecture/OVERVIEW.md#scalability-considerations)** - Horizontal and vertical scaling strategies
 
 ---
 
 ## 📈 **Performance & Monitoring**
 
 ### **Performance Architecture**
-- **[Performance Targets](ARCHITECTURE.md#performance-targets)** - SLA thresholds and optimization goals
-- **[Caching Strategy](ARCHITECTURE.md#caching-strategy)** - Multi-layer caching implementation
-- **[Optimization Patterns](ARCHITECTURE.md#performance-optimization-strategy)** - Async processing and resource management
+- **[Performance Targets](architecture/OVERVIEW.md#performance-requirements)** - SLA thresholds and optimization goals
+- **[Caching Strategy](architecture/COMPONENTS.md#caching-strategy)** - Multi-layer caching implementation
+- **[Optimization Patterns](architecture/OVERVIEW.md#performance-requirements)** - Async processing and resource management
 
 ### **Monitoring & Observability**
-- **[Monitoring Architecture](ARCHITECTURE.md#monitoring--observability)** - Comprehensive monitoring strategy
-- **[Key Performance Indicators](ARCHITECTURE.md#key-performance-indicators)** - Technical and business metrics
-- **[Alerting Strategy](ARCHITECTURE.md#monitoring-architecture)** - Performance and error alerting
+- **[Monitoring Architecture](architecture/COMPONENTS.md#monitoring--observability)** - Comprehensive monitoring strategy
+- **[Key Performance Indicators](architecture/OVERVIEW.md#key-performance-indicators)** - Technical and business metrics
+- **[Alerting Strategy](architecture/COMPONENTS.md#monitoring--observability)** - Performance and error alerting
 
 ---
 
 ## 🔒 **Security & Compliance**
 
 ### **Security Architecture**
-- **[Security Layers](ARCHITECTURE.md#security-architecture)** - Input, processing, and output security
-- **[Security Controls](ARCHITECTURE.md#security-controls)** - Data protection and access controls
-- **[Audit & Compliance](ARCHITECTURE.md#audit--compliance)** - Enterprise compliance support
+- **[Security Layers](architecture/COMPONENTS.md#security-architecture)** - Input, processing, and output security
+- **[Security Controls](architecture/COMPONENTS.md#security-controls)** - Data protection and access controls
+- **[Audit & Compliance](architecture/COMPONENTS.md#audit--compliance)** - Enterprise compliance support
 
 ### **Risk Management**
 - **[Risk Assessment](technical/mcp-integration-technical-assessment.md#risk-assessment--mitigation)** - Technical risk analysis
 - **[Mitigation Strategies](technical/mcp-integration-technical-assessment.md#mitigation-strategies)** - Comprehensive risk mitigation
-- **[Circuit Breaker Patterns](ARCHITECTURE.md#circuit-breaker)** - Graceful degradation and recovery
+- **[Circuit Breaker Patterns](architecture/PATTERNS.md#circuit-breaker)** - Graceful degradation and recovery
 
 ---
 
 ## 🎯 **Implementation Guides**
 
 ### **Quick References**
-- **[Architecture Quick Start](ARCHITECTURE.md#system-overview)** - High-level system understanding
+- **[Architecture Quick Start](architecture/OVERVIEW.md#system-overview)** - High-level system understanding
 - **[Transparency Implementation](../lib/claudedirector/transparency/)** - Complete transparency system code
 - **[Usage Examples](../lib/claudedirector/transparency/phase2_usage_example.py)** - Production usage patterns
 
 ### **Detailed Guides**
-- **[Complete Architecture Documentation](ARCHITECTURE.md)** - Comprehensive system design
+- **[Complete Architecture Documentation](architecture/OVERVIEW.md)** - Comprehensive system design
 - **[MCP Integration Guide](technical/mcp-integration-technical-assessment.md)** - Detailed implementation plan
 - **[Multi-Persona Development](../framework/PERSONAS.md)** - Persona system development
 
@@ -161,14 +161,14 @@
 ## 🔄 **Future Roadmap**
 
 ### **Technical Evolution**
-- **[Future Architecture Roadmap](ARCHITECTURE.md#future-architecture-roadmap)** - Phase 3-5 technical roadmap
-- **[Advanced Multi-Persona](ARCHITECTURE.md#phase-3-advanced-multi-persona-collaboration)** - Real-time collaboration
-- **[Enterprise Integration](ARCHITECTURE.md#phase-5-enterprise-integration)** - Corporate knowledge integration
+- **[Future Architecture Roadmap](architecture/DECISIONS.md#future-architecture-roadmap)** - Phase 3-5 technical roadmap
+- **[Advanced Multi-Persona](architecture/PATTERNS.md#phase-3-advanced-multi-persona-collaboration)** - Real-time collaboration
+- **[Enterprise Integration](architecture/DECISIONS.md#phase-5-enterprise-integration)** - Corporate knowledge integration
 
 ### **Enhancement Pipeline**
-- **[Strategic Memory System](ARCHITECTURE.md#phase-4-intelligent-strategic-memory)** - Organization-specific learning
-- **[Predictive Guidance](ARCHITECTURE.md#phase-4-intelligent-strategic-memory)** - Pattern-based recommendations
-- **[Custom Persona Development](ARCHITECTURE.md#phase-5-enterprise-integration)** - Organization-specific roles
+- **[Strategic Memory System](architecture/DECISIONS.md#phase-4-intelligent-strategic-memory)** - Organization-specific learning
+- **[Predictive Guidance](architecture/DECISIONS.md#phase-4-intelligent-strategic-memory)** - Pattern-based recommendations
+- **[Custom Persona Development](architecture/DECISIONS.md#phase-5-enterprise-integration)** - Organization-specific roles
 
 ---
 
@@ -189,6 +189,6 @@
 
 ---
 
-**Technical Index maintained by Martin (Principal Platform Architect)**  
-**Last Updated**: ClaudeDirector v1.1.1 - Enhanced Architecture Documentation Release  
+**Technical Index maintained by Martin (Principal Platform Architect)**
+**Last Updated**: ClaudeDirector v1.1.1 - Enhanced Architecture Documentation Release
 **Coverage**: Complete technical documentation for transparent AI strategic leadership platform


### PR DESCRIPTION
# 📚 **Documentation Fix: Restore Broken Architecture Links**

## Problem
During AI verbosity cleanup, `ARCHITECTURE.md` was split into focused files in the `architecture/` directory, but 40+ links throughout documentation still pointed to the old `ARCHITECTURE.md` file.

## Solution
Updated all references to point to the appropriate new architecture files:

### **Link Mapping**
- **General architecture** → `architecture/OVERVIEW.md`
- **Transparency System** → `architecture/COMPONENTS.md#transparency-system-architecture`  
- **Multi-Persona Collaboration** → `architecture/PATTERNS.md#multi-persona-collaboration-patterns`
- **Performance Architecture** → `architecture/OVERVIEW.md#performance-requirements`
- **MCP Integration** → `architecture/COMPONENTS.md#mcp-integration-architecture`
- **Future Roadmap** → `architecture/DECISIONS.md`

### **Files Updated**
- `docs/GETTING_STARTED.md` - Architecture guide links
- `docs/ROLES_GUIDE.md` - Architecture guide links  
- `docs/TECHNICAL_INDEX.md` - Comprehensive remapping (25+ links)
- `docs/CHANGELOG.md` - Architecture reference

## Result
✅ All documentation links functional  
✅ Proper navigation to focused architecture content  
✅ No broken links in documentation  
✅ Improved user experience with targeted content

**Documentation navigation is now fully restored!**